### PR TITLE
Add option to keep files in S3 when publishing

### DIFF
--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -44,6 +44,15 @@ Will use settings.AWS_BUCKET_NAME by default."
         help="Display the output of what would have been uploaded \
 removed, but without actually publishing."
     ),
+    make_option(
+        "--keep-files",
+        action="store_true",
+        dest="keep_files",
+        default=False,
+        help=("Keep files in S3, even if they do not exist in the build "
+              "directory. The default behavior is to delete files in the "
+              "bucket that are not in the build directory.")
+    ),
 )
 
 
@@ -105,7 +114,7 @@ settings.py or provide a list as arguments."
         self.sync_with_s3()
 
         # Delete anything that's left in our keys dict
-        if not self.dry_run:
+        if not self.dry_run and not self.keep_files:
             self.deleted_files = len(self.s3_key_dict.keys())
             if self.deleted_files:
                 logger.debug("deleting %s keys" % self.deleted_files)
@@ -184,6 +193,9 @@ No content was changed on S3.")
             logger.info("executing with the --dry-run option set.")
         else:
             self.dry_run = False
+
+        # set the --keep-files option
+        self.keep_files = options.get('keep_files')
 
     def get_s3_key_dict(self):
         """

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -275,7 +275,7 @@ class BakeryTest(TestCase):
         call_command("build", 'bakery.tests.MockDetailView')
 
         # HACK: Running the publish command causes this exception to be raised:
-        # S3DataError: BotoClientError: ETag from S3 did not match computed 
+        # S3DataError: BotoClientError: ETag from S3 did not match computed
         # MD5.
         # I suspect, but haven't confirmed that this is due to the combination
         # of mocking S3 and threading.  We don't really care about that part

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -275,7 +275,8 @@ class BakeryTest(TestCase):
         call_command("build", 'bakery.tests.MockDetailView')
 
         # HACK: Running the publish command causes this exception to be raised:
-        # S3DataError: BotoClientError: ETag from S3 did not match computed MD5.
+        # S3DataError: BotoClientError: ETag from S3 did not match computed 
+        # MD5.
         # I suspect, but haven't confirmed that this is due to the combination
         # of mocking S3 and threading.  We don't really care about that part
         # of the code, so just mock the offending method

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -3,6 +3,9 @@ import os
 import six
 import json
 import django
+import boto
+from boto.s3.key import Key
+from moto import mock_s3
 from .. import views, feeds
 from django.db import models
 from .. import models as bmodels
@@ -12,6 +15,11 @@ from django.http import HttpResponse
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.contrib.contenttypes.models import ContentType
+
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 
 
 class MockObject(bmodels.BuildableModel):
@@ -242,6 +250,46 @@ class BakeryTest(TestCase):
 
     def test_publish_cmd(self):
         pass
+
+    @mock_s3
+    def test_publish_cmd_keep_files(self):
+        """
+        Test that running the publish management command with the
+        --keep-files option does not delete remote files that
+        don't exist in the build directory
+        """
+        aws_bucket_name = 'fake.s3.example.com'
+
+        # Since we're mocking S3, we need to create the mock bucket
+        conn = boto.connect_s3()
+        bucket = conn.create_bucket(aws_bucket_name)
+
+        # Create an item in S3 that isn't in our build directory
+        contents = 'This is a file not in the Django Bakery build'
+        key = 'not_in_build/test.html'
+        k = Key(bucket)
+        k.key = key
+        k.set_contents_from_string(contents)
+
+        # Build our mock site via the build management command
+        call_command("build", 'bakery.tests.MockDetailView')
+
+        # HACK: Running the publish command causes this exception to be raised:
+        # S3DataError: BotoClientError: ETag from S3 did not match computed MD5.
+        # I suspect, but haven't confirmed that this is due to the combination
+        # of mocking S3 and threading.  We don't really care about that part
+        # of the code, so just mock the offending method
+        with patch.object(Key, 'should_retry', return_value=True):
+            # Publish the built site
+            cmd_kwargs = {
+                'keep_files': True,
+                'aws_bucket_name': aws_bucket_name,
+            }
+            call_command('publish', **cmd_kwargs)
+
+            # The key we created should still be in the bucket after publishing
+            k = bucket.get_key(key)
+            self.assertEqual(k.get_contents_as_string(), contents)
 
     def test_unpublish_cmd(self):
         pass

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,10 @@ class TestCommand(Command):
             ),
             MEDIA_URL = '/media/',
             BAKERY_VIEWS = ('bakery.tests.MockDetailView',),
+            # The publish management command needs these to exit, but
+            # we're mocking boto, so we can put nonesense in here
+            AWS_ACCESS_KEY_ID = 'MOCK_ACCESS_KEY_ID',
+            AWS_SECRET_ACCESS_KEY = 'MOCK_SECRET_ACCESS_KEY',
         )
         from django.core.management import call_command
         import django

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ class TestCommand(Command):
         pass
 
     def run(self):
+        if self.distribution.install_requires:
+            self.distribution.fetch_build_eggs(self.distribution.install_requires)
+        if self.distribution.tests_require:
+            self.distribution.fetch_build_eggs(self.distribution.tests_require)
+
         from django.conf import settings
         settings.configure(
             DATABASES={

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,12 @@ import tempfile
 from setuptools import setup
 from distutils.core import Command
 
+test_requires = ['moto']
+try:
+    import unittest.mock
+except ImportError:
+    test_requires.append('mock')
+
 
 class TestCommand(Command):
     user_options = []
@@ -97,5 +103,6 @@ setup(
         'six>=1.5.2',
         'boto>=2.28',
     ],
+    tests_require=test_requires,
     cmdclass={'test': TestCommand}
 )


### PR DESCRIPTION
Add a '--keep-files' option to the publish management command
that causes the command to skip the deletion of files that
have keys in the S3 bucket, but don't exist in the build directory.

This is a simple way to support safer publishing in cases where
items may be written to the S3 bucket outside of the Django
Bakery build/publish workflow.  With this option, users can
publish their Django project with Django Bakery and have the
flexibility to manage other components that publish to the
same S3 bucket outside of Django.

To test this feature, use [moto](https://github.com/spulec/moto)
to mock the boto library, used to interact with S3.  The mock
package is also needed to work around some weirdness with the
S3 mocking that isn't crucial to the feature under test.

Update setup.py to include the testing dependencies.