### PR TITLE
Add setting to allow Cache-Control by content type

### DIFF
--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -293,7 +293,10 @@ No content was changed on S3.")
 
         # add the cache-control heaers if necessary
         if content_type in self.cache_control:
-            headers['Cache-Control'] = 'max-age=%s' % self.cache_control[content_type]
+            headers['Cache-Control'] = ''.join((
+                'max-age=',
+                str(self.cache_control[content_type])
+            ))
 
         # access and write the contents from the file
         with open(filename, 'rb') as file_obj:

--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -154,6 +154,9 @@ No content was changed on S3.")
         # What ACL (i.e. security permissions) will be giving the files on S3?
         self.acl = getattr(settings, 'DEFAULT_ACL', self.DEFAULT_ACL)
 
+        # Should we set cache-control headers?
+        self.cache_control = getattr(settings, 'BAKERY_CACHE_CONTROL', {})
+
         # If the user specifies a build directory...
         if options.get('build_dir'):
             # ... validate that it is good.
@@ -287,6 +290,10 @@ No content was changed on S3.")
         # add the gzip headers, if necessary
         if self.gzip and content_type in self.gzip_content_types:
             headers['Content-Encoding'] = 'gzip'
+
+        # add the cache-control heaers if necessary
+        if content_type in self.cache_control:
+            headers['Cache-Control'] = 'max-age=%s' % self.cache_control[content_type]
 
         # access and write the contents from the file
         with open(filename, 'rb') as file_obj:

--- a/docs/settingsvariables.rst
+++ b/docs/settingsvariables.rst
@@ -8,7 +8,7 @@ ALLOW_BAKERY_AUTO_PUBLISHING
 
 .. envvar:: ALLOW_BAKERY_AUTO_PUBLISHING
 
-    Decides whether the `AutoPublishingBuildableModel` is allowed to run the 
+    Decides whether the `AutoPublishingBuildableModel` is allowed to run the
     `publish` management command as part of its background task. True by default.
 
 .. code-block:: python
@@ -99,9 +99,9 @@ GZIP_CONTENT_TYPES
 .. envvar:: GZIP_CONTENT_TYPES
 
     A list of file mime types used to determine which files to add the
-    'Content-Encoding: gzip' metadata header when syncing to Amazon S3. 
+    'Content-Encoding: gzip' metadata header when syncing to Amazon S3.
     Defaults to include all 'text/css', 'text/html', 'application/javascript',
-    'application/x-javascript', 'application/json' and 'application/xml' 
+    'application/x-javascript', 'application/json' and 'application/xml'
     files.
 
     Only matters if you have set ``BAKERY_GZIP`` to ``True``.
@@ -109,7 +109,7 @@ GZIP_CONTENT_TYPES
 .. code-block:: python
 
     # defaults to 'text/css', 'text/html', 'application/javascript',
-    # 'application/x-javascript', 'application/json' and 'application/xml' 
+    # 'application/x-javascript', 'application/json' and 'application/xml'
     # files.
     GZIP_CONTENT_TYPES = (
         'text/css',
@@ -130,3 +130,17 @@ DEFAULT_ACL
 
     # defaults to 'public-read',
     DEFAULT_ACL = 'public-read'
+
+BAKERY_CACHE_CONTROL
+-----------
+
+.. envvar:: BAKERY_CACHE_CONTROL
+
+    Set cache-control headers based on content type. Headers are set using the ``max-age=`` format so the passed values should be in seconds (``'text/html': 900`` would result in a ``Cache-Control: max-age=900`` header for all ``text/html`` files). By default, none are set.
+
+.. code-block:: python
+
+    BAKERY_CACHE_CONTROL = {
+        'text/html': 900,
+        'application/javascript': 86400
+    }


### PR DESCRIPTION
Includes a potential solution for #31 on a per-content type basis like so:

```python
BAKERY_CACHE_CONTROL = {
    'text/html': 900
}
```

There's also an attempt at updating the docs.

FWIW, I went with `Cache-Control: max-age=` instead of `Expires` because that's what [CloudFront prefers](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html), which is our use case.