### PR TITLE
Allow override for calling format and S3 endpoint

### DIFF
--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -108,7 +108,9 @@ settings.py or provide a list as arguments."
         # Initialize the boto connection
         self.conn = boto.connect_s3(
             settings.AWS_ACCESS_KEY_ID,
-            settings.AWS_SECRET_ACCESS_KEY
+            settings.AWS_SECRET_ACCESS_KEY,
+            calling_format=self.s3_calling_format,
+            host=self.s3_host
         )
 
         # Grab our bucket
@@ -179,6 +181,20 @@ No content was changed on S3.")
 
         # Should we set cache-control headers?
         self.cache_control = getattr(settings, 'BAKERY_CACHE_CONTROL', {})
+
+        # Use a non-standard calling format, if one is specified
+        self.s3_calling_format = getattr(
+            settings,
+            'BAKERY_S3_CALLING_FORMAT',
+            boto.s3.connection.S3Connection.DefaultCallingFormat
+        )
+
+        # Allow the user to specify a non-standard S3 endpoint
+        self.s3_host = getattr(
+            settings,
+            'BAKERY_S3_HOST',
+            boto.s3.connection.S3Connection.DefaultHost
+        )
 
         # If the user specifies a build directory...
         if options.get('build_dir'):

--- a/bakery/management/commands/unpublish.py
+++ b/bakery/management/commands/unpublish.py
@@ -7,8 +7,24 @@ class Command(BaseCommand):
     help = "Empties the Amazon S3 bucket defined in settings.py"
 
     def handle(self, *args, **kwds):
+        # Use a non-standard calling format, if one is specified
+        s3_calling_format = getattr(
+            settings,
+            'BAKERY_S3_CALLING_FORMAT',
+            boto.s3.connection.S3Connection.DefaultCallingFormat
+        )
+
+        # Allow the user to specify a non-standard S3 endpoint
+        s3_host = getattr(
+            settings,
+            'BAKERY_S3_HOST',
+            boto.s3.connection.S3Connection.DefaultHost
+        )
+
         conn = boto.connect_s3(settings.AWS_ACCESS_KEY_ID,
-                               settings.AWS_SECRET_ACCESS_KEY)
+                               settings.AWS_SECRET_ACCESS_KEY,
+                               host=s3_host,
+                               calling_format=s3_calling_format)
         self.bucket = conn.get_bucket(settings.AWS_BUCKET_NAME)
         self.keys = list(key.name for key in self.bucket.list())
         # Break list of keys to delete into list of lists, each with 100 keys


### PR DESCRIPTION
Been dealing with some delightful S3 complications lately related to boto/boto#2836 because we use dots in our bucket names.

So far the only reliable way I've discovered to get around this is to override the calling format and, in some cases, the S3 endpoint as well if you're in a non-standard region.

This PR allows those items to be overridden in settings.py for django-bakery.