### PR TITLE
Only use OrdinaryCallingFormat() if we're on 2.7.9

### DIFF
--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -107,7 +107,7 @@ settings.py or provide a list as arguments."
         self.set_options(options)
 
         # Initialize the boto connection
-        if '.' in self.aws_bucket_name and sys.version_info[:3] >= (2,7,9):
+        if '.' in self.aws_bucket_name and sys.version_info[:3] >= (2, 7, 9):
             # Hack here for the odd bug with Python 2.7.9
             # https://github.com/boto/boto/issues/2836
             self.conn = S3Connection(

--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -107,7 +107,7 @@ settings.py or provide a list as arguments."
         self.set_options(options)
 
         # Initialize the boto connection
-        if '.' in self.aws_bucket_name and sys.version_info[:3] == (2,7,9):
+        if '.' in self.aws_bucket_name and sys.version_info[:3] >= (2,7,9):
             # Hack here for the odd bug with Python 2.7.9
             # https://github.com/boto/boto/issues/2836
             self.conn = S3Connection(

--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import hashlib
 import logging
@@ -106,7 +107,7 @@ settings.py or provide a list as arguments."
         self.set_options(options)
 
         # Initialize the boto connection
-        if '.' in self.aws_bucket_name:
+        if '.' in self.aws_bucket_name and sys.version_info[:3] == (2,7,9):
             # Hack here for the odd bug with Python 2.7.9
             # https://github.com/boto/boto/issues/2836
             self.conn = S3Connection(


### PR DESCRIPTION
The patch for OrdinaryCallingFormat(), 08a6f01, causes a `S3ResponseError: 301 Moved Permanently` error on Python versions before 2.7.9. This patch just checks whether we're >= 2.7.9 before we use that trick.

