### PR TITLE
Removed try/except in build.py

### DIFF
--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -180,11 +180,9 @@ Will use settings.BUILD_DIR by default."
             logger.debug("Building %s" % view_str)
             if self.verbosity > 1:
                 six.print_("Building %s" % view_str)
-            try:
-                view = get_callable(view_str)
-                view().build_method()
-            except (TypeError, ViewDoesNotExist, ImportError):
-                raise CommandError("View %s does not work." % view_str)
+            
+            view = get_callable(view_str)
+            view().build_method()
 
     def copytree_and_gzip(self, source_dir, target_dir):
         """


### PR DESCRIPTION
This try/except in build.py hides valuable errors (and raises a too generic one) that I think users would want to see when building.