### PR TITLE
Only strip slash from start of urls.

### DIFF
--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -129,7 +129,7 @@ Will use settings.BUILD_DIR by default."
             interactive=False,
             verbosity=0
         )
-        target_dir = os.path.join(self.build_dir, settings.STATIC_URL[1:])
+        target_dir = os.path.join(self.build_dir, settings.STATIC_URL.lstrip('/'))
 
         if os.path.exists(settings.STATIC_ROOT) and settings.STATIC_URL:
             if getattr(settings, 'BAKERY_GZIP', False):
@@ -167,7 +167,7 @@ Will use settings.BUILD_DIR by default."
         if os.path.exists(settings.MEDIA_ROOT) and settings.MEDIA_URL:
             shutil.copytree(
                 settings.MEDIA_ROOT,
-                os.path.join(self.build_dir, settings.MEDIA_URL[1:])
+                os.path.join(self.build_dir, settings.MEDIA_URL.lstrip('/'))
             )
 
     def build_views(self):

--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -129,7 +129,10 @@ Will use settings.BUILD_DIR by default."
             interactive=False,
             verbosity=0
         )
-        target_dir = os.path.join(self.build_dir, settings.STATIC_URL.lstrip('/'))
+        target_dir = os.path.join(
+            self.build_dir,
+            settings.STATIC_URL.lstrip('/')
+        )
 
         if os.path.exists(settings.STATIC_ROOT) and settings.STATIC_URL:
             if getattr(settings, 'BAKERY_GZIP', False):

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -184,7 +184,7 @@ class BakeryTest(TestCase):
         for o in MockObject.objects.all():
             build_path = os.path.join(
                 settings.BUILD_DIR,
-                o.get_absolute_url()[1:],
+                o.get_absolute_url().lstrip('/'),
                 'index.html',
             )
             self.assertTrue(os.path.exists(build_path))

--- a/bakery/views/dates.py
+++ b/bakery/views/dates.py
@@ -95,7 +95,7 @@ class BuildableYearArchiveView(YearArchiveView, BuildableMixin):
         would like your page at a different location. By default it
         will be built at self.get_url() + "/index.html"
         """
-        path = os.path.join(settings.BUILD_DIR, self.get_url()[1:])
+        path = os.path.join(settings.BUILD_DIR, self.get_url().lstrip('/'))
         os.path.exists(path) or os.makedirs(path)
         return os.path.join(path, 'index.html')
 
@@ -178,7 +178,7 @@ class BuildableMonthArchiveView(MonthArchiveView, BuildableMixin):
         would like your page at a different location. By default it
         will be built at self.get_url() + "/index.html"
         """
-        path = os.path.join(settings.BUILD_DIR, self.get_url()[1:])
+        path = os.path.join(settings.BUILD_DIR, self.get_url().lstrip('/'))
         os.path.exists(path) or os.makedirs(path)
         return os.path.join(path, 'index.html')
 
@@ -276,7 +276,7 @@ class BuildableDayArchiveView(DayArchiveView, BuildableMixin):
         would like your page at a different location. By default it
         will be built at self.get_url() + "/index.html"
         """
-        path = os.path.join(settings.BUILD_DIR, self.get_url()[1:])
+        path = os.path.join(settings.BUILD_DIR, self.get_url().lstrip('/'))
         os.path.exists(path) or os.makedirs(path)
         return os.path.join(path, 'index.html')
 

--- a/bakery/views/detail.py
+++ b/bakery/views/detail.py
@@ -46,7 +46,7 @@ set a ``get_absolute_url`` method on the %s model or override the %s view's \
         would like your detail page at a different location. By default it
         will be built at get_url() + "index.html"
         """
-        path = os.path.join(settings.BUILD_DIR, self.get_url(obj)[1:])
+        path = os.path.join(settings.BUILD_DIR, self.get_url(obj).lstrip('/'))
         os.path.exists(path) or os.makedirs(path)
         return os.path.join(path, 'index.html')
 


### PR DESCRIPTION
This fixes problems if for instance the `get_url` function returned urls without a starting `/`, in which case the first character of the url path was stripped. Not it only removes the character (or multiple) if it is a `/`.
