### PR TITLE
Use imports supporting Django 2.0, closes #112

### DIFF
--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -10,7 +10,10 @@ from django.conf import settings
 from django.core import management
 from multiprocessing.pool import ThreadPool
 from bakery import DEFAULT_GZIP_CONTENT_TYPES
-from django.core.urlresolvers import get_callable
+try:
+    from django.core.urlresolvers import get_callable
+except ImportError:  # Starting with Django 2.0, django.core.urlresolvers does not exist anymore
+    from django.urls import get_callable
 from django.core.management.base import BaseCommand, CommandError
 logger = logging.getLogger(__name__)
 

--- a/bakery/management/commands/publish.py
+++ b/bakery/management/commands/publish.py
@@ -12,7 +12,10 @@ from bakery.management.commands import (
     get_s3_client,
     get_bucket_page
 )
-from django.core.urlresolvers import get_callable
+try:
+    from django.core.urlresolvers import get_callable
+except ImportError:  # Starting with Django 2.0, django.core.urlresolvers does not exist anymore
+    from django.urls import get_callable
 from django.core.management.base import CommandError
 logger = logging.getLogger(__name__)
 

--- a/bakery/models.py
+++ b/bakery/models.py
@@ -22,7 +22,10 @@ class BuildableModel(models.Model):
     detail_views = []
 
     def _get_view(self, name):
-        from django.core.urlresolvers import get_callable
+        try:
+            from django.core.urlresolvers import get_callable
+        except ImportError:  # Starting with Django 2.0, django.core.urlresolvers does not exist anymore
+            from django.urls import get_callable
         return get_callable(name)
 
     def _build_related(self):

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -13,7 +13,10 @@ from bakery import DEFAULT_GZIP_CONTENT_TYPES
 from django.test.client import RequestFactory
 from bakery.management.commands import get_s3_client
 from django.views.generic import RedirectView, TemplateView
-from django.core.urlresolvers import reverse, NoReverseMatch
+try:
+    from django.core.urlresolvers import reverse, NoReverseMatch
+except ImportError:  # Starting with Django 2.0, django.core.urlresolvers does not exist anymore
+    from django.urls import reverse, NoReverseMatch
 logger = logging.getLogger(__name__)
 
 

--- a/example/date_views/models.py
+++ b/example/date_views/models.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 from django.db import models
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:  # Starting with Django 2.0, django.core.urlresolvers does not exist anymore
+    from django.urls import reverse
 
 
 class Article(models.Model):


### PR DESCRIPTION
Since I wasn't sure which Django versions you wish to support, I used a conditional import with a comment explaining the matter – if you want to support only Django versions starting at 1.9 (I think), we'd be safe in removing the old import entirely.