### PR TITLE
move filesystem attribute from ready to the root of BakeryConfig

### DIFF
--- a/bakery/apps.py
+++ b/bakery/apps.py
@@ -8,8 +8,9 @@ logger = logging.getLogger(__name__)
 class BakeryConfig(AppConfig):
     name = 'bakery'
     verbose_name = "Bakery"
-
+    filesystem_name = getattr(settings, 'BAKERY_FILESYSTEM', "osfs:///")
+    logger.debug("Loading filesystem at {}".format(filesystem_name))
+    filesystem = fs.open_fs(self.filesystem_name)
+    
     def ready(self):
-        self.filesystem_name = getattr(settings, 'BAKERY_FILESYSTEM', "osfs:///")
-        logger.debug("Loading filesystem at {}".format(self.filesystem_name))
-        self.filesystem = fs.open_fs(self.filesystem_name)
+        pass

--- a/bakery/apps.py
+++ b/bakery/apps.py
@@ -11,6 +11,6 @@ class BakeryConfig(AppConfig):
     filesystem_name = getattr(settings, 'BAKERY_FILESYSTEM', "osfs:///")
     logger.debug("Loading filesystem at {}".format(filesystem_name))
     filesystem = fs.open_fs(filesystem_name)
-    
+
     def ready(self):
         pass

--- a/bakery/apps.py
+++ b/bakery/apps.py
@@ -10,7 +10,7 @@ class BakeryConfig(AppConfig):
     verbose_name = "Bakery"
     filesystem_name = getattr(settings, 'BAKERY_FILESYSTEM', "osfs:///")
     logger.debug("Loading filesystem at {}".format(filesystem_name))
-    filesystem = fs.open_fs(self.filesystem_name)
+    filesystem = fs.open_fs(filesystem_name)
     
     def ready(self):
         pass


### PR DESCRIPTION
If filesystem attribute is added in ready function then it is missing at the models initializing stage. So it breaks wagtail_bakery and potentially any other package if it happens to import from your views.py at its model initializing stage.