### PR TITLE
Adds get_build_path to BuildableTemplateView, which can handle a build_path property set to reverse_lazy

### DIFF
--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -20,7 +20,6 @@ from django.http import HttpResponse
 from django.core.management import call_command
 from django.test import TestCase, RequestFactory, override_settings
 from django.core.exceptions import ImproperlyConfigured
-from unittest.mock import Mock
 
 try:
     from django.urls import reverse_lazy
@@ -33,10 +32,15 @@ except ImportError:  # Django <2.0
     from django.conf.urls import url
 
 
+def mock_url_view(*args, **kwargs):
+    # url objects require a function
+    pass
+
+
 urlpatterns = [
-    url('filename.html', Mock(), name='filename'),
-    url('directory/filename.html', Mock(), name='directory_and_filename'),
-    url('nested/directory/filename.html', Mock(), name='nested_directory_and_filename'),
+    url('filename.html', mock_url_view, name='filename'),
+    url('directory/filename.html', mock_url_view, name='directory_and_filename'),
+    url('nested/directory/filename.html', mock_url_view, name='nested_directory_and_filename'),
 ]
 
 

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -135,7 +135,7 @@ class BakeryTest(TestCase):
             obj.unbuild()
             obj.get_absolute_url()
 
-    def test_template_view(self):
+    def test_template_view_with_explicit_filename(self):
         v = views.BuildableTemplateView(
             template_name='templateview.html',
             build_path='foo.html',
@@ -145,6 +145,8 @@ class BakeryTest(TestCase):
         build_path = os.path.join(settings.BUILD_DIR, 'foo.html')
         self.assertTrue(os.path.exists(build_path))
         os.remove(build_path)
+
+    def test_template_view_with_directory_and_explicit_filename(self):
         v = views.BuildableTemplateView(
             template_name='templateview.html',
             build_path='foo/bar.html',
@@ -333,7 +335,8 @@ class BakeryTest(TestCase):
         with self.settings(BAKERY_GZIP=True):
             six.print_("testing gzipped files")
             self.test_models()
-            self.test_template_view()
+            self.test_template_view_with_explicit_filename()
+            self.test_template_view_with_directory_and_explicit_filename()
             self.test_list_view()
             self.test_detail_view()
             self.test_404_view()

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -157,6 +157,17 @@ class BakeryTest(TestCase):
         self.assertTrue(os.path.exists(build_path))
         os.remove(build_path)
 
+    def test_template_view_with_nested_directory_and_explicit_filename(self):
+        v = views.BuildableTemplateView(
+            template_name='templateview.html',
+            build_path='nested/foo/bar.html',
+        )
+        v.build_method
+        v.build()
+        build_path = os.path.join(settings.BUILD_DIR, 'nested', 'foo', 'bar.html')
+        self.assertTrue(os.path.exists(build_path))
+        os.remove(build_path)
+
     def test_list_view(self):
         v = views.BuildableListView(
             queryset=[1, 2, 3],
@@ -337,6 +348,7 @@ class BakeryTest(TestCase):
             self.test_models()
             self.test_template_view_with_explicit_filename()
             self.test_template_view_with_directory_and_explicit_filename()
+            self.test_template_view_with_nested_directory_and_explicit_filename()
             self.test_list_view()
             self.test_detail_view()
             self.test_404_view()

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -36,7 +36,7 @@ except ImportError:  # Django <2.0
 urlpatterns = [
     url('filename.html', Mock(), name='filename'),
     url('directory/filename.html', Mock(), name='directory_and_filename'),
-    url('ntested/directory/filename.html', Mock(), name='nested_directory_and_filename'),
+    url('nested/directory/filename.html', Mock(), name='nested_directory_and_filename'),
 ]
 
 

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -145,10 +145,14 @@ class BuildableTemplateView(TemplateView, BuildableMixin):
 
     def build(self):
         logger.debug("Building %s" % self.template_name)
-        self.request = self.create_request(self.build_path)
-        path = os.path.join(settings.BUILD_DIR, self.build_path)
-        self.prep_directory(self.build_path)
+        build_path = self.get_build_path()
+        self.request = self.create_request(build_path)
+        path = os.path.join(settings.BUILD_DIR, build_path)
+        self.prep_directory(build_path)
         self.build_file(path, self.get_content())
+
+    def get_build_path(self):
+        return six.text_type(self.build_path).lstrip('/')
 
 
 class Buildable404View(BuildableTemplateView):


### PR DESCRIPTION
I've added a `get_build_path` method to BuildableTemplateView. This coerces the `build_path` property to text, and strips any preceding '`/`', which allows us to set build_path to `reverse_lazy` values. This partially resolves issue #120 (we're not handling 'directory' paths yet).

There is some related further work I'd like to complete, but I didn't want to create a huge diff in one pull request. If this gets accepted, I'll continue work on:
* Handling `build_path` (and `reverse_lazy`) values which do not include an explicit filename (similar to how `BuildableDetailView` works), e.g. handling a value of "`/about/`", without having to specify "`about/index.html`". This would include a setting to allow an alternative "default" filename, rather than hard-coding '`index.html`' in python code in multiple places.
* Eventually moving common "build_path" functionality from Buildable[Template/Detail/List/Date]Views to the base "BuildableMixin".