### PR TITLE
Revamp BuildableFeed to support multiple subjects

### DIFF
--- a/bakery/feeds.py
+++ b/bakery/feeds.py
@@ -1,4 +1,5 @@
 import os
+import six
 import logging
 from django.conf import settings
 from bakery.views import BuildableMixin
@@ -12,16 +13,63 @@ class BuildableFeed(Feed, BuildableMixin):
     """
     build_path = 'feed.xml'
 
-    def get_content(self):
-        return self(self.request).content
+    def get_content(self, *args, **kwargs):
+        return self(self.request, *args, **kwargs).content
 
     @property
     def build_method(self):
         return self.build_queryset
 
+    def _get_bakery_dynamic_attr(self, attname, obj, args=None, default=None):
+        """
+        Allows subclasses to provide an attribute (say, 'foo') in three
+        different ways: As a fixed class-level property or as a method
+        foo(self) or foo(self, obj). The second argument argument 'obj' is
+        the "subject" of the current Feed invocation. See the Django Feed
+        documentation for details.
+
+        This method was shamelessly stolen from the Feed class and extended
+        with the ability to pass additional arguments to subclass methods.
+        """
+        try:
+            attr = getattr(self, attname)
+        except AttributeError:
+            return default
+
+        if callable(attr) or args:
+            args = args[:] if args else []
+
+            # Check co_argcount rather than try/excepting the function and
+            # catching the TypeError, because something inside the function
+            # may raise the TypeError. This technique is more accurate.
+            try:
+                code = six.get_function_code(attr)
+            except AttributeError:
+                code = six.get_function_code(attr.__call__)
+            if code.co_argcount == 2 + len(args):  # one argument is 'self'
+                args.append(obj)
+                return attr(*args)
+            elif code.co_argcount == 1 + len(args):
+                return attr(*args)
+            else:
+                return attr()
+
+        return attr
+
+    def get_queryset(self):
+        return [None]
+
     def build_queryset(self):
-        logger.debug("Building %s" % self.build_path)
-        self.request = self.create_request(self.build_path)
-        self.prep_directory(self.build_path)
-        path = os.path.join(settings.BUILD_DIR, self.build_path)
-        self.build_file(path, self.get_content())
+        for obj in self.get_queryset():
+            build_path = self._get_bakery_dynamic_attr('build_path', obj)
+            url = self._get_bakery_dynamic_attr('feed_url', obj)
+
+            logger.debug("Building %s" % build_path)
+
+            self.request = self._get_bakery_dynamic_attr(
+                'create_request', obj, args=[url or build_path])
+
+            self.prep_directory(build_path)
+            path = os.path.join(settings.BUILD_DIR, build_path)
+            content = self._get_bakery_dynamic_attr('get_content', obj)
+            self.build_file(path, content)

--- a/docs/buildablefeeds.rst
+++ b/docs/buildablefeeds.rst
@@ -20,23 +20,57 @@ BuildableFeed
 
     .. py:attribute:: build_method
 
-        An alias to the ``build_queryset`` method used by the :doc:`management commands </managementcommands>`
+        An alias to the ``build_queryset`` method used by the :doc:`management commands </managementcommands>`.
 
     .. py:method:: build_queryset()
 
         Writes the rendered template's HTML to a flat file. Only override this if you know what you're doing.
 
+    .. py:method:: get_queryset()
+
+        The ``Feed`` class allows a single feed instance to return different content for requests to different URLs.
+        The "subject" for a request is determinted by the object returned from the ``get_object`` method, by default ``None``.
+        (See `the Django docs <https://docs.djangoproject.com/en/dev/ref/contrib/syndication/#a-complex-example>` for details.)
+        Override this method to provide a collection of "subjects" for which bakery should render the feed.
+
+        As in Django, you can replace certain bakery feed attributes (such as ``build_path``) with methods that accept the subject as an extra "obj" parameter.
+
     **Example myapp/feeds.py**
 
     .. code-block:: python
 
-        from myapp.models import MyModel
+        import os
+        from myapp.models import MyModel, MyParentModel
         from bakery.feeds import BuildableFeed
 
 
         class ExampleRSSFeed(BuildableFeed):
-            link = 'http://www.mysite.com/rss.xml'
+            link = '/'
+            feed_url = '/rss.xml'
             build_path = 'rss.xml'
 
             def items(self):
                 return MyModel.objects.filter(is_published=True)
+
+
+        class ExampleFeedWithSubject(BuildableFeed):
+            def get_object(self, request, obj_id):
+                return MyParentModel.objects.get(pk=obj_id)
+
+            def get_queryset(self):
+                return MyParentModel.objects.filter(is_published=True)
+
+            def get_content(self, obj):
+                return super().get_content(obj.id)
+
+            def link(self, obj):
+                return obj.get_absolute_url()
+
+            def feed_url(self, obj):
+                return os.path.join(obj.get_absolute_url(), 'rss.xml')
+
+            def build_path(self, obj):
+                return self.feed_url(obj)[1:]  # Discard initial slash
+
+            def items(self, obj):
+                return MyModel.objects.filter(parent__id=obj.id)


### PR DESCRIPTION
Django's Feed class lets you reuse the same instance for multiple feed "subjects" - see the documentation changes below for a brief explanation and [this Django page](https://docs.djangoproject.com/en/2.0/ref/contrib/syndication/#a-complex-example) for more details. Right now, BuildableFeed only renders a single page per feed. I've tried to extend it in a way that's stylistically compatible with the base class while maintaining existing behavior in the single-subject case.

Intentional behavior changes:

- We now use the value returned from `feed_url` instead of `build_path` in the mock request object if the former value is defined.

Open questions:

- The `get_content` method feels like a bit of a rough edge. Any multi-subject feed where the content depends on the subject (presumably most of them) will need to override that method in order to present the correct arguments to the `get_object` method. Less obviously, the override is also necessary for `_get_bakery_dynamic_attr` to pass the feed subject as an extra argument. Open to suggestions on how to make that nicer.

- I've never dealt with Python 2/3 compatibility before - am I allowed to use `str`?