### PR TITLE
Fix typo in BuildableDetailView docs

### DIFF
--- a/docs/buildableviews.rst
+++ b/docs/buildableviews.rst
@@ -196,7 +196,7 @@ BuildableDetailView
         from bakery.views import BuildableDetailView
 
 
-        class ExampleDetailView(BuildableListView):
+        class ExampleDetailView(BuildableDetailView):
             queryset = MyModel.objects.filter(is_published=True)
             template_name = 'mymodel_detail.html'
 


### PR DESCRIPTION
Fix small typo in docs, replacing BuildableListView for BuildableDetailView.